### PR TITLE
Use new TabletProperties revision attributes

### DIFF
--- a/OpenTabletDriver.udev/OpenTabletDriver.udev.csproj
+++ b/OpenTabletDriver.udev/OpenTabletDriver.udev.csproj
@@ -13,11 +13,11 @@
 
   <ItemGroup>
     <PackageReference Include="System.CommandLine.Experimental" Version="0.3.0-alpha.19577.1" />
-    <PackageReference Include="TabletDriverPlugin" Version="0.2.1" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\libudev.Rules\libudev.Rules.csproj" />
+    <ProjectReference Include="..\..\OpenTabletDriver\TabletDriverPlugin\TabletDriverPlugin.csproj" />
   </ItemGroup>
 
 </Project>

--- a/OpenTabletDriver.udev/RuleCreator.cs
+++ b/OpenTabletDriver.udev/RuleCreator.cs
@@ -9,24 +9,22 @@ namespace OpenTabletDriver.udev
     {
         public static Rule CreateAccessRule(TabletProperties tablet, string mode)
         {
-            return new Rule(new Token[]
-            {
+            return new Rule(
                 new Token("SUBSYSTEM", Operator.Equal, "hidraw"),
-                new ATTRS("idVendor", Operator.Equal, tablet.VendorID.ToHexFormat()),
-                new ATTRS("idProduct", Operator.Equal, tablet.ProductID.ToHexFormat()),
-                new Token("MODE", Operator.Assign, mode),
-            });
+                new ATTRS("idVendor", Operator.Equal, tablet.DigitizerIdentifier.VendorID.ToHexFormat()),
+                new ATTRS("idProduct", Operator.Equal, tablet.DigitizerIdentifier.ProductID.ToHexFormat()),
+                new Token("MODE", Operator.Assign, mode)
+            );
         }
 
         public static Rule CreateOverrideRule(TabletProperties tablet)
         {
-            return new Rule(new Token[]
-            {
+            return new Rule(
                 new Token("SUBSYSTEM", Operator.Equal, "input"),
-                new ATTRS("idVendor", Operator.Equal, tablet.VendorID.ToHexFormat()),
-                new ATTRS("idProduct", Operator.Equal, tablet.ProductID.ToHexFormat()),
+                new ATTRS("idVendor", Operator.Equal, tablet.DigitizerIdentifier.VendorID.ToHexFormat()),
+                new ATTRS("idProduct", Operator.Equal, tablet.DigitizerIdentifier.ProductID.ToHexFormat()),
                 new ENV("LIBINPUT_IGNORE_DEVICE", Operator.Assign, "1")
-            });
+            );
         }
     }
 }

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,4 @@
+configurations=$PWD/../OpenTabletDriver/TabletDriverLib/Configurations
+rules=$PWD/build/30-opentabletdriver.rules
+
+dotnet run -p $PWD/OpenTabletDriver.udev/*.csproj -- -v "${configurations}" "${rules}"

--- a/libudev.Rules/Rule.cs
+++ b/libudev.Rules/Rule.cs
@@ -10,7 +10,7 @@ namespace libudev.Rules
         {
         }
 
-        public Rule(IEnumerable<Token> tokens)
+        public Rule(params Token[] tokens)
         {
             Tokens = tokens;
         }

--- a/pack.sh
+++ b/pack.sh
@@ -1,3 +1,0 @@
-dotnet pack
-dotnet tool uninstall -g OpenTabletDriver.udev
-dotnet tool install -g --add-source ./OpenTabletDriver.udev/nupkg OpenTabletDriver.udev


### PR DESCRIPTION
# Changes
- [x] Use `TabletProperties.Attributes` to identify tablets requiring libinput override
  - [x] Write override if attributed