### PR TITLE
Add USB subsystem access rule

### DIFF
--- a/OpenTabletDriver.udev/Program.cs
+++ b/OpenTabletDriver.udev/Program.cs
@@ -57,7 +57,8 @@ namespace OpenTabletDriver.udev
                 if (string.IsNullOrWhiteSpace(tablet.Name))
                     continue;
                 yield return string.Format("# {0}", tablet.Name);
-                yield return RuleCreator.CreateAccessRule(tablet, "0666");
+                yield return RuleCreator.CreateAccessRule(tablet, "hidraw", "0666");
+                yield return RuleCreator.CreateAccessRule(tablet, "usb", "0666");
                 if (tablet.Attributes.TryGetValue("libinputoverride", out var value) && (value == "1" || value.ToLower() == "true"))
                     yield return RuleCreator.CreateOverrideRule(tablet);
             }

--- a/OpenTabletDriver.udev/RuleCreator.cs
+++ b/OpenTabletDriver.udev/RuleCreator.cs
@@ -7,10 +7,10 @@ namespace OpenTabletDriver.udev
 {
     internal static class RuleCreator
     {
-        public static Rule CreateAccessRule(TabletProperties tablet, string mode)
+        public static Rule CreateAccessRule(TabletProperties tablet, string subsystem, string mode)
         {
             return new Rule(
-                new Token("SUBSYSTEM", Operator.Equal, "hidraw"),
+                new Token("SUBSYSTEM", Operator.Equal, subsystem),
                 new ATTRS("idVendor", Operator.Equal, tablet.DigitizerIdentifier.VendorID.ToHexFormat()),
                 new ATTRS("idProduct", Operator.Equal, tablet.DigitizerIdentifier.ProductID.ToHexFormat()),
                 new Token("MODE", Operator.Assign, mode)


### PR DESCRIPTION
# Changes
Add USB subsystem rule to provide access to `/dev/bus/usb/bbb/ddd` for the devices.